### PR TITLE
ci: build package before pages deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",
     "test:ci": "cross-env CI=1 jest",
-    "predeploy": "cd example && yarn install && yarn run build",
+    "predeploy": "yarn build && cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",
     "prepare": "husky install"
   },


### PR DESCRIPTION
- chore: updated example site to test out the credentials
- feat: add isSandbox prop to select the environment
- chore: removed typedoc
- chore: add environment selection to example site
- ci: build package before pages deployment
